### PR TITLE
Feat : NamingStrategy

### DIFF
--- a/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.OutOfProc/Program.cs
+++ b/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.OutOfProc/Program.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.OutOfP
                                     },
                                     Servers = DefaultOpenApiConfigurationOptions.GetHostNames(),
                                     OpenApiVersion = DefaultOpenApiConfigurationOptions.GetOpenApiVersion(),
+                                    OpenApiNamingStrategy = DefaultOpenApiConfigurationOptions.GetOpenApiNamingStrategy(),
                                     ExcludeRequestingHost = DefaultOpenApiConfigurationOptions.IsRequestingHostExcluded(),
                                     ForceHttps = DefaultOpenApiConfigurationOptions.IsHttpsForced(),
                                     ForceHttp = DefaultOpenApiConfigurationOptions.IsHttpForced(),

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.InProc/Startup.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.InProc/Startup.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.InProc
                                     },
                                     Servers = DefaultOpenApiConfigurationOptions.GetHostNames(),
                                     OpenApiVersion = DefaultOpenApiConfigurationOptions.GetOpenApiVersion(),
+                                    OpenApiNamingStrategy = DefaultOpenApiConfigurationOptions.GetOpenApiNamingStrategy(),
                                     ExcludeRequestingHost = DefaultOpenApiConfigurationOptions.IsRequestingHostExcluded(),
                                     ForceHttps = DefaultOpenApiConfigurationOptions.IsHttpsForced(),
                                     ForceHttp = DefaultOpenApiConfigurationOptions.IsHttpForced(),

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
@@ -129,7 +129,24 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi
         public virtual ISwaggerUI SwaggerUI { get; }
 
         /// <inheritdoc />
-        public virtual NamingStrategy NamingStrategy { get; } = new CamelCaseNamingStrategy();
+        public virtual NamingStrategy NamingStrategy { 
+        get
+            { 
+                switch (this._configOptions.NamingStrategy)
+                {
+                    case NamingStrategyType.CamelCase:
+                        return new CamelCaseNamingStrategy();
+                    case NamingStrategyType.PascalCase:
+                        return new DefaultNamingStrategy();
+                    case NamingStrategyType.SnakeCase:
+                        return new SnakeCaseNamingStrategy();
+                    case NamingStrategyType.KebabCase:
+                        return new KebabCaseNamingStrategy();
+                    default:
+                        return new CamelCaseNamingStrategy();
+                }
+            }
+        }
 
         /// <inheritdoc />
         public virtual bool IsDevelopment { get; } = Environment.GetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT") == "Development";

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IOpenApiConfigurationOptions.cs
@@ -49,5 +49,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
         /// Gets or sets the <see cref="IOpenApiHttpTriggerAuthorization"/> instance for Swagger endpoints.
         /// </summary>
         IOpenApiHttpTriggerAuthorization Security { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating OpenApiNamingStrategy.
+        /// </summary>
+        OpenApiNamingStrategy OpenApiNamingStrategy { get; set; } 
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         private const string ExcludeRequestingHostKey = "OpenApi__ExcludeRequestingHost";
         private const string ForceHttpKey = "OpenApi__ForceHttp";
         private const string ForceHttpsKey = "OpenApi__ForceHttps";
+        private const string OpenApiNamingStrategyKey = "OpenApi__NamingStrategy";
 
         /// <inheritdoc />
         public override OpenApiInfo Info { get; set; } = new OpenApiInfo()
@@ -54,6 +55,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
 
         /// <inheritdoc />
         public override IOpenApiHttpTriggerAuthorization Security { get; set; } = new DefaultOpenApiHttpTriggerAuthorization();
+
+        /// <inheritdoc />
+        public override OpenApiNamingStrategy OpenApiNamingStrategy { get; set; } = GetOpenApiNamingStrategy();
 
         /// <summary>
         /// Gets the OpenAPI document version.
@@ -163,6 +167,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
             return forceHttps;
         }
 
+        public static OpenApiNamingStrategy GetOpenApiNamingStrategy()
+        {
+            var result = Enum.TryParse<OpenApiNamingStrategy>(
+                                Environment.GetEnvironmentVariable(OpenApiNamingStrategyKey));
+            return result ? result : DefaultOpenApiNamingStrategy();
+        }
         private static OpenApiVersionType DefaultOpenApiVersion()
         {
             return OpenApiVersionType.V2;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiConfigurationOptions.cs
@@ -36,5 +36,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
 
         /// <inheritdoc />
         public virtual IOpenApiHttpTriggerAuthorization Security { get; set; } = new OpenApiHttpTriggerAuthorization();
+
+        /// <inheritdoc />
+        public virtual OpenApiNamingStrategy OpenApiNamingStrategy { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Enums/OpenApiNamingStrategy.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Enums/OpenApiNamingStrategy.cs
@@ -1,0 +1,28 @@
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums
+{
+    /// <summary>
+    /// This specifies the naming strategy for OpenAPI.
+    /// </summary>
+    public enum OpenApiNamingStrategy
+    {
+        /// <summary>
+        /// Identifies the default naming strategy.
+        /// </summary>
+        CamelCase = 0,
+
+        /// <summary>
+        /// Identifies the PascalCase naming strategy.
+        /// </summary>
+        PascalCase = 1,
+
+        /// <summary>
+        /// Identifies the snake_case naming strategy.
+        /// </summary>
+        SnakeCase = 2,
+
+        /// <summary>
+        /// Identifies the kebab-case naming strategy.
+        /// </summary>
+        KebabCase = 3
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
@@ -36,5 +36,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers
 
             return options as IOpenApiConfigurationOptions;
         }
+    
+        /// <summary>
+        /// Gets the <see cref="IOpenApiConfigurationOptions"/> instance from the given strategyType.
+        /// </summary>
+        /// <param name="strategyType">The naming strategy type.</param>
+        /// <returns>Returns the NamingStrategy instance resolved.(Override)</returns>
+        public static NamingStrategy Resolve(NamingStrategyType strategyType)
+        {
+            switch (strategyType)
+            {
+                case NamingStrategyType.CamelCase:
+                    return new CamelCaseNamingStrategy();
+                case NamingStrategyType.PascalCase:
+                    return new DefaultNamingStrategy();
+                case NamingStrategyType.SnakeCase:
+                    return new SnakeCaseNamingStrategy();
+                case NamingStrategyType.KebabCase:
+                    return new KebabCaseNamingStrategy();
+                default:
+                    return new CamelCaseNamingStrategy();
+            }
+        }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
@@ -128,7 +128,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
         public virtual ISwaggerUI SwaggerUI { get; }
 
         /// <inheritdoc />
-        public virtual NamingStrategy NamingStrategy { get; } = new CamelCaseNamingStrategy();
+        public virtual NamingStrategy NamingStrategy { 
+            get
+            { 
+                switch (this._configOptions.NamingStrategy)
+                {
+                    case NamingStrategyType.CamelCase:
+                        return new CamelCaseNamingStrategy();
+                    case NamingStrategyType.PascalCase:
+                        return new DefaultNamingStrategy();
+                    case NamingStrategyType.SnakeCase:
+                        return new SnakeCaseNamingStrategy();
+                    case NamingStrategyType.KebabCase:
+                        return new KebabCaseNamingStrategy();
+                    default:
+                        return new CamelCaseNamingStrategy();
+                }
+            }
+        }
 
         /// <inheritdoc />
         public virtual bool IsDevelopment { get; } = Environment.GetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT") == "Development";

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
@@ -131,19 +131,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
         public virtual NamingStrategy NamingStrategy { 
             get
             { 
-                switch (this._configOptions.NamingStrategy)
-                {
-                    case NamingStrategyType.CamelCase:
-                        return new CamelCaseNamingStrategy();
-                    case NamingStrategyType.PascalCase:
-                        return new DefaultNamingStrategy();
-                    case NamingStrategyType.SnakeCase:
-                        return new SnakeCaseNamingStrategy();
-                    case NamingStrategyType.KebabCase:
-                        return new KebabCaseNamingStrategy();
-                    default:
-                        return new CamelCaseNamingStrategy();
-                }
+                return OpenApiConfigurationResolver.Resolve(this._configOptions.NamingStrategy);
             }
         }
 


### PR DESCRIPTION
요구사항:
IOpenApiConfigurationOptions 인터페이스에 boolean 타입의 NamingStrategy 속성 추가
DefaultOpenApiConfigurationOptions 클래스에 위 속성 구현 및 정적 메소드, NamingStrategyType enum 반환하는 GetNamingStrategy() 구현.
NamingStrategyType enum 개체는 CamelCase, PascalCase, SnakeCase, KebabCase 항목 포함
GetNamingStrategy() 메소드는 local.settings.json 파일에서 OpenApi__NamingStrategy 값을 읽어 해당 값에 따라 적절한 enum 값을 반환.  기본값은 CamelCase 반환
위 속성 값에 따라 적정한 NamingStrategy 인스턴스 생성 후 전달 

위 가이드 대로 수정했습니다.