### PR TITLE
FEAT: Testcase for Resolver(Naming Strategy)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers
         /// Gets the <see cref="IOpenApiConfigurationOptions"/> instance from the given strategyType.
         /// </summary>
         /// <param name="strategyType">The naming strategy type.</param>
-        /// <returns>Returns the NamingStrategy instance resolved.(Override)</returns>
+        /// <returns>Returns the NamingStrategy instance resolved.(Overload)</returns>
         public static NamingStrategy Resolve(NamingStrategyType strategyType)
         {
             switch (strategyType)

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
@@ -51,5 +51,86 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Resolvers
             result.Should().BeOfType<FakeOpenApiConfigurationOptions>();
             result.GetType().BaseType.Should().Be(typeof(FakeOpenApiConfigurationOptionsBase)); // This verifies the abstract type was considered in the resolution
         }
+
+        /// <summary>
+        /// This tests are added to cover the switch statement in the Resolve method.
+        /// </summary>
+        [TestMethod]
+        public void Given_CamelCase_When_Resolve_Invoked_Then_It_Should_Return_CamelCaseNamingStrategy()
+        {
+            var strategyType = NamingStrategyType.CamelCase;
+
+            var result = OpenApiConfigurationResolver.Resolve(strategyType);
+
+            result.Should().BeOfType<CamelCaseNamingStrategy>();
+        }
+
+        [TestMethod]
+        public void Given_PascalCase_When_Resolve_Invoked_Then_It_Should_Return_DefaultNamingStrategy()
+        {
+            var strategyType = NamingStrategyType.PascalCase;
+
+            var result = OpenApiConfigurationResolver.Resolve(strategyType);
+
+            result.Should().BeOfType<DefaultNamingStrategy>();
+        }
+
+        [TestMethod]
+        public void Given_SnakeCase_When_Resolve_Invoked_Then_It_Should_Return_SnakeCaseNamingStrategy()
+        {
+            var strategyType = NamingStrategyType.SnakeCase;
+
+            var result = OpenApiConfigurationResolver.Resolve(strategyType);
+
+            result.Should().BeOfType<SnakeCaseNamingStrategy>();
+        }
+
+        [TestMethod]
+        public void Given_KebabCase_When_Resolve_Invoked_Then_It_Should_Return_KebabCaseNamingStrategy()
+        {
+            var strategyType = NamingStrategyType.KebabCase;
+
+            var result = OpenApiConfigurationResolver.Resolve(strategyType);
+
+            result.Should().BeOfType<KebabCaseNamingStrategy>();
+        }
+
+        [TestMethod]
+        public void Given_SnakeCase_number_When_Resolve_Invoked_Then_It_Should_Return_SnakeCaseNamingStrategy()
+        {
+            var strategyType = (NamingStrategyType)2; 
+
+            var result = OpenApiConfigurationResolver.Resolve(strategyType);
+
+            result.Should().BeOfType<SnakeCaseNamingStrategy>();
+        }
+
+        [TestMethod]
+        public void Given_UnexpectedValue_When_Resolve_Invoked_Then_It_Should_Return_CamelCaseNamingStrategy()
+        {
+            var strategyType = (NamingStrategyType)999; 
+
+            var result = OpenApiConfigurationResolver.Resolve(strategyType);
+
+            result.Should().BeOfType<CamelCaseNamingStrategy>();
+        }
+
+
+        [TestMethod]
+        public void Given_Null_When_Resolve_Invoked_Then_It_Should_Return_CamelCaseNamingStrategy()
+        {
+            var result = OpenApiConfigurationResolver.Resolve(null);
+
+            result.Should().BeOfType<CamelCaseNamingStrategy>();
+        }
+
+        [TestMethod]
+        public void Given_Null_When_Resolve_Invoked_Then_It_Should_Return_DefaultOpenApiConfigurationOptions()
+        {
+            var result = OpenApiConfigurationResolver.Resolve(null);
+
+            result.Should().BeOfType<DefaultOpenApiConfigurationOptions>();
+        }
+
     }
 }


### PR DESCRIPTION
ADD: 8Case of tests for testing Resolve method
- Given_CamelCase_When_Resolve_Invoked_Then_It_Should_Return_CamelCaseNamingStrategy
- Given_PascalCase_When_Resolve_Invoked_Then_It_Should_Return_DefaultNamingStrategy
- Given_SnakeCase_When_Resolve_Invoked_Then_It_Should_Return_SnakeCaseNamingStrategy
- Given_KebabCase_When_Resolve_Invoked_Then_It_Should_Return_KebabCaseNamingStrategy
- Given_SnakeCase_number_When_Resolve_Invoked_Then_It_Should_Return_SnakeCaseNamingStrategy
- Given_UnexpectedValue_When_Resolve_Invoked_Then_It_Should_Return_CamelCaseNamingStrategy
- Given_Null_When_Resolve_Invoked_Then_It_Should_Return_CamelCaseNamingStrategy
- Given_Null_When_Resolve_Invoked_Then_It_Should_Return_DefaultOpenApiConfigurationOptions

CHORE: fix summary in resolve method(override to overload)